### PR TITLE
Make JS version actually use int32 additions by truncating

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -4,7 +4,7 @@ function djb2js (input) {
   var hash = 5381
 
   for (var i = 0; i < input.length; i++) {
-    hash += (hash << 5) + input[i]
+    hash = hash + ((hash << 5) + input[i] | 0) | 0;
   }
 
   return hash
@@ -14,7 +14,7 @@ function djb2js_xor (input) {
   var hash = 5381
 
   for (var i = 0; i < input.length; i++) {
-    hash += (hash << 5) ^ input[i]
+    hash = hash + ((hash << 5) ^ input[i]) | 0;
   }
 
   return hash


### PR DESCRIPTION
```
$ node bench.js
Start
js (add): 4909.255ms
b390d842
js (xor): 4745.730ms
8c94c642
```